### PR TITLE
Optional `dmget` kwarg to transfer data to disk before opening it

### DIFF
--- a/gfdl_utils/core.py
+++ b/gfdl_utils/core.py
@@ -45,7 +45,7 @@ def open_frompp(pp,ppname,out,local,time,add,dmget=False,**kwargs):
         print("Issuing dmget command to migrate data to disk.", end=" ")
         issue_dmget(paths)
         while not(query_all_ondisk(paths)):
-            time_module.sleep(5.)
+            time_module.sleep(1.)
         print("Migration complete.")
     return xr.open_mfdataset(paths, use_cftime=True, **kwargs)
 

--- a/gfdl_utils/core.py
+++ b/gfdl_utils/core.py
@@ -42,10 +42,11 @@ def open_frompp(pp,ppname,out,local,time,add,dmget=False,**kwargs):
         for v in add:
             paths += glob.glob(get_pathspp(pp,ppname,out,local,time,v))
     if dmget:
+        print("Issuing dmget command to migrate data to disk.", end=" ")
         issue_dmget(paths)
         while not(query_all_ondisk(paths)):
-            print("Querying")
             time_module.sleep(5.)
+        print("Migration complete.")
     return xr.open_mfdataset(paths, use_cftime=True, **kwargs)
 
 def get_pathspp(pp,ppname,out,local,time,add):

--- a/gfdl_utils/core.py
+++ b/gfdl_utils/core.py
@@ -40,8 +40,7 @@ def open_frompp(pp,ppname,out,local,time,add,dmget=False,**kwargs):
     elif isinstance(add, list):
         paths = []
         for v in add:
-            for path in glob.glob(get_pathspp(pp,ppname,out,local,time,v)):
-                paths = paths + path
+            paths += glob.glob(get_pathspp(pp,ppname,out,local,time,v))
     if dmget:
         issue_dmget(paths)
         while not(query_all_ondisk(paths)):


### PR DESCRIPTION
I find my workflow is much more streamlines if I just (optionally) include a `dmget` before loading any data. I often find myself forgetting to dmget some of the files or trying to load them while they are still migrating, and therefore being stuck at the data-loading step for a long time.

This PR includes an optional `dmget` kwarg (defaulting to `False`) to `open_frompp` that, if true, uses the `issue_dmget` function to run the `dmget` command and then a new `query_all_ondisk` function that calls `query_ondisk` to check that all of the requested data file paths are on disk. It only moves on the the `xr.open_mfdataset` command after the query confirms that all of the necessary data files are available on disk.